### PR TITLE
Add skeleton Python package for Braggard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.ruff_cache/
+.pytest_cache/

--- a/braggard.toml
+++ b/braggard.toml
@@ -1,0 +1,7 @@
+[user]
+handle = "your-github-username"
+include_private = false
+
+[metrics]
+ci_pass_window = 100
+commit_history_years = 3

--- a/braggard/__init__.py
+++ b/braggard/__init__.py
@@ -1,0 +1,15 @@
+"""Braggard package initialization."""
+
+__all__ = [
+    "collect",
+    "analyze",
+    "render",
+    "deploy",
+]
+
+from .collector import collect
+from .analyzer import analyze
+from .renderer import render
+from .deployer import deploy
+
+__version__ = "0.1.0"

--- a/braggard/__main__.py
+++ b/braggard/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for ``python -m braggard``."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/braggard/analyzer.py
+++ b/braggard/analyzer.py
@@ -1,0 +1,8 @@
+"""Data analysis for Braggard."""
+
+from __future__ import annotations
+
+
+def analyze() -> None:
+    """Placeholder analyzer implementation."""
+    raise NotImplementedError("analyze() needs implementation")

--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -1,0 +1,49 @@
+"""Command line interface for Braggard."""
+
+from __future__ import annotations
+
+import click
+
+from .collector import collect
+from .analyzer import analyze
+from .renderer import render
+from .deployer import deploy
+
+
+@click.group()
+def main() -> None:
+    """Braggard command line entry point."""
+
+
+@main.command()
+@click.argument("user")
+@click.option("--token", envvar="BRAGGARD_TOKEN")
+@click.option("--include-private", is_flag=True)
+@click.option("--since")
+def collect_cmd(
+    user: str, token: str | None, include_private: bool, since: str | None
+) -> None:
+    """Fetch data from GitHub."""
+    collect(user=user, token=token, include_private=include_private, since=since)
+
+
+@main.command()
+def analyze_cmd() -> None:
+    """Analyze collected data."""
+    analyze()
+
+
+@main.command()
+def render_cmd() -> None:
+    """Render static site."""
+    render()
+
+
+@main.command()
+def deploy_cmd() -> None:
+    """Deploy docs to gh-pages."""
+    deploy()
+
+
+if __name__ == "__main__":
+    main()

--- a/braggard/collector.py
+++ b/braggard/collector.py
@@ -1,0 +1,14 @@
+"""Data collection from the GitHub API."""
+
+from __future__ import annotations
+
+
+def collect(
+    *,
+    user: str,
+    token: str | None = None,
+    include_private: bool = False,
+    since: str | None = None,
+) -> None:
+    """Placeholder collector implementation."""
+    raise NotImplementedError("collect() needs implementation")

--- a/braggard/deployer.py
+++ b/braggard/deployer.py
@@ -1,0 +1,8 @@
+"""Docs deployment."""
+
+from __future__ import annotations
+
+
+def deploy() -> None:
+    """Placeholder deployer implementation."""
+    raise NotImplementedError("deploy() needs implementation")

--- a/braggard/renderer.py
+++ b/braggard/renderer.py
@@ -1,0 +1,8 @@
+"""Static site renderer."""
+
+from __future__ import annotations
+
+
+def render() -> None:
+    """Placeholder renderer implementation."""
+    raise NotImplementedError("render() needs implementation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "braggard"
+version = "0.1.0"
+description = "Automated portfolio-stats generator for GitHub developers"
+authors = [{ name = "Sean Evans", email = "sean@evans.dev" }]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "click>=8.1",
+]
+
+[project.scripts]
+braggard = "braggard.cli:main"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,5 @@
+from braggard import __version__
+
+
+def test_version():
+    assert isinstance(__version__, str)


### PR DESCRIPTION
## Summary
- introduce initial Python package layout
- implement CLI entrypoint with placeholder subcommands
- add project configuration files and sample config
- include minimal tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c2ab334848328a3146de11e168e88