### PR TITLE
Implement GitHub Pages deploy feature

### DIFF
--- a/braggard/deployer.py
+++ b/braggard/deployer.py
@@ -1,8 +1,29 @@
-"""Docs deployment."""
+"""Docs deployment utilities."""
 
 from __future__ import annotations
 
+from datetime import datetime
+import subprocess
+
 
 def deploy() -> None:
-    """Placeholder deployer implementation."""
-    raise NotImplementedError("deploy() needs implementation")
+    """Publish ``docs/`` to the ``gh-pages`` branch.
+
+    This mirrors the ``deploy.sh`` workflow described in the specification.
+    The function is idempotent and safe to re-run. Any errors from committing
+    an unchanged tree are ignored.
+    """
+
+    subprocess.run(["git", "fetch"], check=True)
+    result = subprocess.run(["git", "switch", "gh-pages"], check=False)
+    if result.returncode != 0:
+        subprocess.run(["git", "switch", "-c", "gh-pages"], check=True)
+
+    subprocess.run(["rsync", "-a", "--delete", "docs/", "."], check=True)
+    subprocess.run(["git", "add", "."], check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"braggard: {datetime.utcnow().date()}"],
+        check=False,
+    )
+    subprocess.run(["git", "push", "origin", "gh-pages"], check=True)
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy docs/ to the gh-pages branch
+
+git fetch
+if ! git switch gh-pages; then
+  git switch -c gh-pages
+fi
+rsync -a --delete docs/ .
+
+git add .
+if git commit -m "braggard: $(date +%F)"; then
+  echo "Committed deployment"
+else
+  echo "No changes to commit"
+fi
+
+git push origin gh-pages

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -1,0 +1,20 @@
+import subprocess
+from unittest import mock
+import braggard.deployer as d
+
+
+def test_deploy_runs_commands(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        class R:
+            returncode = 1 if cmd[:3] == ["git", "switch", "gh-pages"] else 0
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    d.deploy()
+
+    assert ["git", "fetch"] in calls
+    assert ["git", "switch", "-c", "gh-pages"] in calls
+    assert ["git", "push", "origin", "gh-pages"] in calls


### PR DESCRIPTION
## Summary
- implement `deploy()` according to roadmap
- add `deploy.sh` script for manual or CI deployments
- test that `deploy()` issues expected git commands

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2d4d35688328a9bbc03424328196