### PR TITLE
Use pre-commit for lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install ruff pytest
+          pip install pre-commit pytest
 
-      - name: Run ruff format check
-        run: ruff format --check .
-
-      - name: Run ruff linter
-        run: ruff check .
-
-      - name: Run tests
-        run: pytest -q
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.3
+    hooks:
+      - id: ruff-format
+      - id: ruff
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,11 @@ First off, thanks for taking the time to contribute! 🎉
 * Be nice – follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
 * Use conventional commits (`feat:`, `fix:`, `docs:` …).
 * All new code **must** have unit tests (`pytest`) and type hints (`mypy` clean).
-* Run the formatter (`ruff format`) and linter (`ruff check`) before every push.
+* Run `pre-commit` before every push.
 
 ```bash
 pip install -r requirements-dev.txt
-ruff format .
-ruff check .
-pytest
+pre-commit run --all-files
 ```
 
 ## Workflow

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pre-commit
+pytest
+ruff


### PR DESCRIPTION
## Summary
- run ruff and pytest via pre-commit
- call pre-commit from CI
- update contributing instructions
- add dev requirements file

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `ruff format --check .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686c2d9d5800832889fe08fd33be2705