### PR TITLE
Add analyzer and renderer functionality

### DIFF
--- a/braggard/analyzer.py
+++ b/braggard/analyzer.py
@@ -2,7 +2,54 @@
 
 from __future__ import annotations
 
+from collections import Counter
+from datetime import datetime, timezone
+import glob
+import json
+import os
+
+
+def _load_snapshots() -> list[dict]:
+    """Return a combined list of repositories from ``data/*.json``."""
+    repos: list[dict] = []
+    for path in sorted(glob.glob(os.path.join("data", "*.json"))):
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            repos.extend(data)
+        else:
+            repos.extend(data.get("repos", []))
+    if not repos:
+        raise FileNotFoundError("No snapshot data found in data/")
+    return repos
+
 
 def analyze() -> None:
-    """Placeholder analyzer implementation."""
-    raise NotImplementedError("analyze() needs implementation")
+    """Analyze collected JSON and write ``summary.json``."""
+
+    repos = _load_snapshots()
+
+    lang_counter: Counter[str] = Counter()
+    total_stars = 0
+    for repo in repos:
+        total_stars += int(repo.get("stargazerCount", 0))
+        lang = repo.get("primaryLanguage") or {}
+        name = lang.get("name")
+        if name:
+            lang_counter[str(name)] += 1
+
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repos": [
+            {"name": r.get("name"), "stars": r.get("stargazerCount", 0)} for r in repos
+        ],
+        "aggregate": {
+            "repo_count": len(repos),
+            "total_stars": total_stars,
+            "languages": dict(lang_counter),
+        },
+    }
+
+    with open("summary.json", "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+

--- a/braggard/renderer.py
+++ b/braggard/renderer.py
@@ -2,7 +2,49 @@
 
 from __future__ import annotations
 
+import json
+import os
+from textwrap import dedent
+
+from jinja2 import Template
+
+
+HTML_TEMPLATE = Template(
+    dedent(
+        """
+        <!DOCTYPE html>
+        <html lang="en">
+        <meta charset="utf-8" />
+        <title>Braggard Report</title>
+        <body>
+        <h1>Braggard Report</h1>
+        <p>Generated at {{ summary.generated_at }}</p>
+        <h2>Aggregates</h2>
+        <ul>
+          <li>Total repos: {{ summary.aggregate.repo_count }}</li>
+          <li>Total stars: {{ summary.aggregate.total_stars }}</li>
+        </ul>
+        <h2>Languages</h2>
+        <ul>
+        {% for lang, count in summary.aggregate.languages.items() %}
+          <li>{{ lang }}: {{ count }}</li>
+        {% endfor %}
+        </ul>
+        </body>
+        </html>
+        """
+    )
+)
+
 
 def render() -> None:
-    """Placeholder renderer implementation."""
-    raise NotImplementedError("render() needs implementation")
+    """Render ``summary.json`` into ``docs/index.html``."""
+
+    with open("summary.json", "r", encoding="utf-8") as f:
+        summary = json.load(f)
+
+    os.makedirs("docs", exist_ok=True)
+    output = HTML_TEMPLATE.render(summary=summary)
+    with open(os.path.join("docs", "index.html"), "w", encoding="utf-8") as f:
+        f.write(output)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "click>=8.1",
+    "jinja2>=3.1",
 ]
 
 [project.scripts]

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,24 @@
+import json
+from braggard import analyzer
+
+
+def test_analyze_creates_summary(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sample = [
+        {
+            "name": "demo",
+            "stargazerCount": 5,
+            "primaryLanguage": {"name": "Python"},
+        }
+    ]
+    (data_dir / "snap.json").write_text(json.dumps(sample))
+    monkeypatch.chdir(tmp_path)
+
+    analyzer.analyze()
+
+    summary_file = tmp_path / "summary.json"
+    summary = json.loads(summary_file.read_text())
+    assert summary["aggregate"]["repo_count"] == 1
+    assert summary["aggregate"]["total_stars"] == 5
+    assert summary["aggregate"]["languages"]["Python"] == 1

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+from braggard import renderer
+
+
+def test_render_creates_html(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "summary.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    renderer.render()
+
+    html_file = tmp_path / "docs" / "index.html"
+    assert html_file.exists()
+    content = html_file.read_text()
+    assert "Braggard Report" in content


### PR DESCRIPTION
## Summary
- add Jinja2 dependency
- implement `analyze` to generate `summary.json`
- implement `render` to create basic HTML report
- test analyzer and renderer

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c3088943883288c0cf60d55884d49