### PR TITLE
Fix tests path issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: pytest -q
+        entry: python -m pytest -q
         language: system
         pass_filenames: false

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -1,5 +1,4 @@
 import subprocess
-from unittest import mock
 import braggard.deployer as d
 
 
@@ -8,8 +7,10 @@ def test_deploy_runs_commands(monkeypatch):
 
     def fake_run(cmd, check=False):
         calls.append(cmd)
+
         class R:
             returncode = 1 if cmd[:3] == ["git", "switch", "gh-pages"] else 0
+
         return R()
 
     monkeypatch.setattr(subprocess, "run", fake_run)


### PR DESCRIPTION
## Summary
- ensure pytest entry in pre-commit uses module execution
- clean up unused import in deployer test

## Testing
- `pre-commit run --files tests/test_deployer.py tests/test_import.py .pre-commit-config.yaml`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c307baebc8328be9b40bc260ee31e