### PR TITLE
Add CLI version option and test

### DIFF
--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+from braggard import __version__
 
 from .collector import collect
 from .analyzer import analyze
@@ -11,6 +12,7 @@ from .deployer import deploy
 
 
 @click.group()
+@click.version_option(__version__)
 def main() -> None:
     """Braggard command line entry point."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,8 @@
+from click.testing import CliRunner
+from braggard.cli import main
+
+
+def test_cli_version():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- expose `braggard` version via CLI using `click.version_option`
- test that `braggard --version` exits cleanly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c33581b8c83289851f111f63c4faa