### PR TITLE
Improve error handling for collector

### DIFF
--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,0 +1,15 @@
+import urllib.error
+import urllib.request
+
+import pytest
+
+from braggard import collector
+
+
+def test_request_error_raises(monkeypatch):
+    def fail(_):
+        raise urllib.error.URLError("boom")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fail)
+    with pytest.raises(RuntimeError, match="Request to GitHub failed"):
+        collector._request("query", {}, None)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from braggard import renderer
 
 


### PR DESCRIPTION
## Summary
- log failing GitHub requests and raise `RuntimeError`
- remove unused import from tests
- test collector request failures

## Testing
- `pre-commit run --files braggard/collector.py tests/test_renderer.py tests/test_collector.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3359a6a48328b1e2e048cc0b1eeb