### PR TITLE
Automate ruff-format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -23,4 +25,25 @@ jobs:
           pip install pre-commit pytest
 
       - name: Run pre-commit
+        id: precommit
+        run: |
+          set +e
+          pre-commit run --all-files --show-diff-on-failure
+          status=$?
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "formatting_changed=true" >> "$GITHUB_OUTPUT"
+            status=0
+          fi
+          exit $status
+
+      - name: Commit formatting changes
+        if: steps.precommit.outputs.formatting_changed == 'true'
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git commit -am "chore: apply ruff formatting"
+          git push
+
+      - name: Re-run pre-commit
+        if: steps.precommit.outputs.formatting_changed == 'true'
         run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Summary
- auto-commit ruff-format changes in CI so the build doesn't fail

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_686c3614b8948328824263e38e74e7bf