### PR TITLE
Handle missing summary in renderer

### DIFF
--- a/braggard/renderer.py
+++ b/braggard/renderer.py
@@ -40,6 +40,9 @@ HTML_TEMPLATE = Template(
 def render() -> None:
     """Render ``summary.json`` into ``docs/index.html``."""
 
+    if not os.path.exists("summary.json"):
+        raise FileNotFoundError("Run `braggard analyze` first")
+
     with open("summary.json", "r", encoding="utf-8") as f:
         summary = json.load(f)
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from braggard import renderer
 
 
@@ -17,3 +18,10 @@ def test_render_creates_html(tmp_path, monkeypatch):
     assert html_file.exists()
     content = html_file.read_text()
     assert "Braggard Report" in content
+
+
+def test_render_requires_summary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Run `braggard analyze` first"):
+        renderer.render()


### PR DESCRIPTION
## Summary
- handle missing `summary.json` in `render`
- add a regression test for the error message

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3861c2b4832886de01afbfbb0fa4