### PR TITLE
Add configurable data_dir option

### DIFF
--- a/braggard.toml
+++ b/braggard.toml
@@ -5,3 +5,6 @@ include_private = false
 [metrics]
 ci_pass_window = 100
 commit_history_years = 3
+
+[paths]
+data_dir = "data"

--- a/braggard/analyzer.py
+++ b/braggard/analyzer.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import datetime, timezone
-import glob
 import json
-import os
+from pathlib import Path
+
+from .config import load_config
 
 
-def _load_snapshots() -> list[dict]:
-    """Return a combined list of repositories from ``data/*.json``."""
+def _load_snapshots(data_dir: str | Path | None = None) -> list[dict]:
+    """Return a combined list of repositories from ``data_dir/*.json``."""
+    if data_dir is None:
+        cfg = load_config()
+        data_dir = cfg.get("paths", {}).get("data_dir", "data")
+    data_dir = Path(data_dir)
     repos: list[dict] = []
-    for path in sorted(glob.glob(os.path.join("data", "*.json"))):
+    for path in sorted(data_dir.glob("*.json")):
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         if isinstance(data, list):
@@ -20,14 +25,21 @@ def _load_snapshots() -> list[dict]:
         else:
             repos.extend(data.get("repos", []))
     if not repos:
-        raise FileNotFoundError("No snapshot data found in data/")
+        raise FileNotFoundError(f"No snapshot data found in {data_dir}/")
     return repos
 
 
-def analyze() -> None:
-    """Analyze collected JSON and write ``summary.json``."""
+def analyze(*, data_dir: str | Path | None = None) -> None:
+    """Analyze collected JSON and write ``summary.json``.
 
-    repos = _load_snapshots()
+    Parameters
+    ----------
+    data_dir:
+        Optional directory containing snapshot JSON files. Defaults to the
+        ``paths.data_dir`` value from ``braggard.toml``.
+    """
+
+    repos = _load_snapshots(data_dir)
 
     lang_counter: Counter[str] = Counter()
     total_stars = 0
@@ -52,4 +64,3 @@ def analyze() -> None:
 
     with open("summary.json", "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
-

--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -22,17 +22,29 @@ def main() -> None:
 @click.option("--token", envvar="BRAGGARD_TOKEN")
 @click.option("--include-private", is_flag=True)
 @click.option("--since")
+@click.option("--data-dir", type=click.Path(), help="Directory for snapshot JSON")
 def collect_cmd(
-    user: str, token: str | None, include_private: bool, since: str | None
+    user: str,
+    token: str | None,
+    include_private: bool,
+    since: str | None,
+    data_dir: str | None,
 ) -> None:
     """Fetch data from GitHub."""
-    collect(user=user, token=token, include_private=include_private, since=since)
+    collect(
+        user=user,
+        token=token,
+        include_private=include_private,
+        since=since,
+        data_dir=data_dir,
+    )
 
 
 @main.command()
-def analyze_cmd() -> None:
+@click.option("--data-dir", type=click.Path(), help="Directory with snapshot JSON")
+def analyze_cmd(data_dir: str | None) -> None:
     """Analyze collected data."""
-    analyze()
+    analyze(data_dir=data_dir)
 
 
 @main.command()

--- a/braggard/config.py
+++ b/braggard/config.py
@@ -22,4 +22,5 @@ def load_config(path: str | Path | None = None) -> dict[str, Any]:
     return {
         "user": data.get("user", {}),
         "metrics": data.get("metrics", {}),
+        "paths": data.get("paths", {}),
     }

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -15,7 +15,7 @@ def test_analyze_creates_summary(tmp_path, monkeypatch):
     (data_dir / "snap.json").write_text(json.dumps(sample))
     monkeypatch.chdir(tmp_path)
 
-    analyzer.analyze()
+    analyzer.analyze(data_dir=data_dir)
 
     summary_file = tmp_path / "summary.json"
     summary = json.loads(summary_file.read_text())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ def test_load_config(tmp_path, monkeypatch):
     toml = (
         "[user]\nhandle='demo'\ninclude_private=true\n"
         "[metrics]\nci_pass_window=42\ncommit_history_years=2\n"
+        "[paths]\ndata_dir='snapshots'\n"
     )
     (tmp_path / "braggard.toml").write_text(toml)
     monkeypatch.chdir(tmp_path)
@@ -13,3 +14,4 @@ def test_load_config(tmp_path, monkeypatch):
 
     assert cfg["user"]["handle"] == "demo"
     assert cfg["metrics"]["commit_history_years"] == 2
+    assert cfg["paths"]["data_dir"] == "snapshots"


### PR DESCRIPTION
## Summary
- configure data directory in `braggard.toml`
- allow `collector.collect` and `analyzer` to accept a custom data directory
- expose `--data-dir` CLI options for `collect` and `analyze`
- update tests for new configuration option

## Testing
- `pre-commit run --files braggard/analyzer.py braggard/collector.py braggard/cli.py braggard/config.py tests/test_analyzer.py tests/test_config.py braggard.toml`

------
https://chatgpt.com/codex/tasks/task_e_686c386112cc83289444ad8c52960f1c