### PR TITLE
Support custom render output dir

### DIFF
--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -48,9 +48,15 @@ def analyze_cmd(data_dir: str | None) -> None:
 
 
 @main.command()
-def render_cmd() -> None:
+@click.option(
+    "--output-dir",
+    default="docs",
+    type=click.Path(),
+    help="Directory for rendered site",
+)
+def render_cmd(output_dir: str) -> None:
     """Render static site."""
-    render()
+    render(output_dir=output_dir)
 
 
 @main.command()

--- a/braggard/renderer.py
+++ b/braggard/renderer.py
@@ -37,8 +37,8 @@ HTML_TEMPLATE = Template(
 )
 
 
-def render() -> None:
-    """Render ``summary.json`` into ``docs/index.html``."""
+def render(output_dir: str = "docs") -> None:
+    """Render ``summary.json`` into ``output_dir/index.html``."""
 
     if not os.path.exists("summary.json"):
         raise FileNotFoundError("Run `braggard analyze` first")
@@ -46,7 +46,7 @@ def render() -> None:
     with open("summary.json", "r", encoding="utf-8") as f:
         summary = json.load(f)
 
-    os.makedirs("docs", exist_ok=True)
+    os.makedirs(output_dir, exist_ok=True)
     output = HTML_TEMPLATE.render(summary=summary)
-    with open(os.path.join("docs", "index.html"), "w", encoding="utf-8") as f:
+    with open(os.path.join(output_dir, "index.html"), "w", encoding="utf-8") as f:
         f.write(output)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 from click.testing import CliRunner
 from braggard.cli import main
 
@@ -6,3 +7,19 @@ def test_cli_version():
     runner = CliRunner()
     result = runner.invoke(main, ["--version"])
     assert result.exit_code == 0
+
+
+def test_cli_render_custom_dir(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "summary.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["render", "--output-dir", "public"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / "public" / "index.html").exists()

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -20,6 +20,21 @@ def test_render_creates_html(tmp_path, monkeypatch):
     assert "Braggard Report" in content
 
 
+def test_render_custom_output_dir(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "summary.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    renderer.render(output_dir="public")
+
+    html_file = tmp_path / "public" / "index.html"
+    assert html_file.exists()
+
+
 def test_render_requires_summary(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- allow specifying an output directory for rendered site
- expose `--output-dir` option in CLI
- test rendering to custom path via API and CLI

## Testing
- `pre-commit run --files braggard/renderer.py braggard/cli.py tests/test_renderer.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3ab1a2e083288783cf4d2aef8c99