### PR TITLE
Handle API error responses in collector

### DIFF
--- a/braggard/collector.py
+++ b/braggard/collector.py
@@ -26,11 +26,16 @@ def _request(query: str, variables: dict[str, str | None], token: str | None) ->
     )
     try:
         with urllib.request.urlopen(req) as resp:  # type: ignore[attr-defined]
-            return json.load(resp)
+            data = json.load(resp)
     except (HTTPError, URLError) as exc:  # pragma: no cover - network errors
         msg = f"Request to GitHub failed: {exc}"
         logging.error(msg)
         raise RuntimeError(msg) from exc
+    if isinstance(data, dict) and data.get("errors"):
+        msg = f"GitHub API errors: {data['errors']}"
+        logging.error(msg)
+        raise RuntimeError(msg)
+    return data
 
 
 def collect(

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,3 +1,5 @@
+import io
+import json
 import urllib.error
 import urllib.request
 
@@ -12,4 +14,22 @@ def test_request_error_raises(monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", fail)
     with pytest.raises(RuntimeError, match="Request to GitHub failed"):
+        collector._request("query", {}, None)
+
+
+def test_request_api_errors_raise(monkeypatch):
+    class FakeResp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_urlopen(_):
+        data = {"errors": [{"message": "bad"}]}
+        return FakeResp(json.dumps(data).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="GitHub API errors"):
         collector._request("query", {}, None)


### PR DESCRIPTION
## Summary
- log and raise `RuntimeError` when GitHub API returns errors
- test handling of API error responses in `_request`

## Testing
- `pre-commit run --files braggard/collector.py tests/test_collector.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3aac98588328b507a38b40bcbd51