### PR TITLE
Add pythonpath helper for tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 pre-commit
 pytest
 ruff
+jinja2>=3.1
+click>=8.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure repository root is on PYTHONPATH so tests can import the package
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)


### PR DESCRIPTION
## Summary
- add helper module so tests can import the package without installation
- list runtime dependencies in `requirements-dev.txt`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c3aafd87c8328ba0c96459c887221