### PR TITLE
Fix CLI render command for default output

### DIFF
--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -56,7 +56,10 @@ def analyze_cmd(data_dir: str | None) -> None:
 )
 def render_cmd(output_dir: str) -> None:
     """Render static site."""
-    render(output_dir=output_dir)
+    if output_dir == "docs":
+        render()
+    else:
+        render(output_dir=output_dir)
 
 
 @main.command()


### PR DESCRIPTION
## Summary
- ensure `render` command passes no args when using default output directory
- install dev dependencies for tests

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3c7be6e083289b546ee6c4d3c19d