### PR TITLE
Improve config search logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ braggard deploy   # → pushes docs/ to gh-pages
 
 Or simply enable the supplied **GitHub Action** (`.github/workflows/braggard.yml`) and let it run unattended.
 
+## 📝 Configuration
+
+Braggard reads settings from `braggard.toml`. The file is searched for in
+this order:
+
+1. the path given on the command line or passed to `load_config`
+2. `./braggard.toml` in the current directory
+3. `$XDG_CONFIG_HOME/braggard/braggard.toml` or
+   `~/.config/braggard/braggard.toml`
+
+The first file found is used; otherwise a `FileNotFoundError` is raised.
+
 ---
 
 ## 📚 Docs & meta‑files

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from braggard.config import load_config
 
 
@@ -15,3 +17,41 @@ def test_load_config(tmp_path, monkeypatch):
     assert cfg["user"]["handle"] == "demo"
     assert cfg["metrics"]["commit_history_years"] == 2
     assert cfg["paths"]["data_dir"] == "snapshots"
+
+
+def test_load_config_explicit_path(tmp_path):
+    toml = (
+        "[user]\nhandle='demo'\ninclude_private=true\n"
+        "[metrics]\nci_pass_window=42\ncommit_history_years=2\n"
+        "[paths]\ndata_dir='snapshots'\n"
+    )
+    cfg_file = tmp_path / "cfg.toml"
+    cfg_file.write_text(toml)
+
+    cfg = load_config(cfg_file)
+
+    assert cfg["user"]["handle"] == "demo"
+
+
+def test_load_config_user_config_dir(tmp_path, monkeypatch):
+    toml = (
+        "[user]\nhandle='demo'\ninclude_private=true\n"
+        "[metrics]\nci_pass_window=42\ncommit_history_years=2\n"
+        "[paths]\ndata_dir='snapshots'\n"
+    )
+    conf_dir = tmp_path / "xdg" / "braggard"
+    conf_dir.mkdir(parents=True)
+    (conf_dir / "braggard.toml").write_text(toml)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.chdir(tmp_path)
+
+    cfg = load_config()
+
+    assert cfg["metrics"]["ci_pass_window"] == 42
+
+
+def test_load_config_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    with pytest.raises(FileNotFoundError):
+        load_config()


### PR DESCRIPTION
## Summary
- search multiple default locations for `braggard.toml`
- document config search path
- test new fallback behaviour

## Testing
- `pre-commit run --files braggard/config.py README.md tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_686c408199508328a875221c68a291c5