### PR TITLE
Simplify render command call

### DIFF
--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -56,10 +56,7 @@ def analyze_cmd(data_dir: str | None) -> None:
 )
 def render_cmd(output_dir: str) -> None:
     """Render static site."""
-    if output_dir == "docs":
-        render()
-    else:
-        render(output_dir=output_dir)
+    render(output_dir=output_dir)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,14 +38,16 @@ def test_cli_analyze_invokes_analyze(monkeypatch):
 def test_cli_render_invokes_render(monkeypatch):
     called = {}
 
-    def fake_render():
+    def fake_render(output_dir="docs"):
         called["called"] = True
+        called["output_dir"] = output_dir
 
     monkeypatch.setattr("braggard.cli.render", fake_render)
     runner = CliRunner()
     result = runner.invoke(main, ["render"])
     assert result.exit_code == 0
     assert called.get("called") is True
+    assert called.get("output_dir") == "docs"
 
 
 def test_cli_deploy_invokes_deploy(monkeypatch):


### PR DESCRIPTION
## Summary
- use `render(output_dir=output_dir)` in CLI
- update CLI render test for new signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c40804cc883288c6cda925fbfa4cc