### PR TITLE
Fix Python version reference

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@
 
 | Component  | Runs in | Language | Packaged as |
 |------------|---------|----------|-------------|
-| Collector  | local CLI / Action | Python 3.12 (optionally Rust) | `braggard` console script |
+| Collector  | local CLI / Action | Python 3.11+ (optionally Rust) | `braggard` console script |
 | Analyzer   | same    | Python (pandas) | module |
 | Renderer   | same    | Python + Jinja  | module |
 | Deployer   | GitHub Action | Bash | script |


### PR DESCRIPTION
## Summary
- fix runtime environment docs to show Python 3.11+

## Testing
- `pre-commit run --files ARCHITECTURE.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c407e6758832887189f9a1d328f9a