### PR TITLE
Add User-Agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It scans your repositories, extracts rich metrics, and publishes a shareable Git
 | **Beautiful dashboards** | Responsive static site built with Jinja + Chart.js + Tailwind, dark‑mode ready |
 | **Automated deployment** | GitHub Action pushes updates to `gh-pages` nightly or on‑push |
 | **Private‑repo friendly** | Supply a fine‑grained PAT and Braggard can include your private work in aggregate stats |
+| **GitHub‑friendly requests** | Adds `User-Agent: braggard/<version>` to API calls |
 | **Social preview image** | Optional OG image generator so links look great on social media |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -13,8 +13,9 @@
 
 ### 2.1 Collector
 
-* **Input** – GitHub username, optional token, CLI flags  
-* **Output** – timestamped raw JSON dump per run  
+* **Input** – GitHub username, optional token, CLI flags
+* **Output** – timestamped raw JSON dump per run
+* Requests send `User-Agent: braggard/<version>`
 * **Data points fetched**  
   * repo name, description, homepage, primaryLanguage  
   * stars, forks, watchers  

--- a/braggard/__init__.py
+++ b/braggard/__init__.py
@@ -1,5 +1,7 @@
 """Braggard package initialization."""
 
+__version__ = "0.1.0"
+
 __all__ = [
     "collect",
     "analyze",
@@ -13,5 +15,3 @@ from .analyzer import analyze
 from .renderer import render
 from .deployer import deploy
 from .config import load_config
-
-__version__ = "0.1.0"

--- a/braggard/collector.py
+++ b/braggard/collector.py
@@ -10,6 +10,7 @@ import urllib.request
 from urllib.error import HTTPError, URLError
 
 from .config import load_config
+from . import __version__
 
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
@@ -18,7 +19,7 @@ GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 def _request(query: str, variables: dict[str, str | None], token: str | None) -> dict:
     """Execute a GraphQL request and return the parsed JSON."""
     payload = json.dumps({"query": query, "variables": variables}).encode()
-    headers = {"Accept": "application/json"}
+    headers = {"Accept": "application/json", "User-Agent": f"braggard/{__version__}"}
     if token:
         headers["Authorization"] = f"bearer {token}"
     req = urllib.request.Request(


### PR DESCRIPTION
## Summary
- send a User-Agent header in collector requests
- expose `__version__` before imports to avoid circular imports
- document header behavior in README and SPEC

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686d5acb375c83289d2e1737484d9d0b