### PR TITLE
Add custom summary path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ braggard render
 braggard deploy   # → pushes docs/ to gh-pages
 ```
 
+The `braggard render` command accepts `--summary-path` to load a summary JSON
+from a custom location instead of the default `summary.json`.
+
 Or simply enable the supplied **GitHub Action** (`.github/workflows/braggard.yml`) and let it run unattended.
 
 ## 📝 Configuration

--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -54,9 +54,15 @@ def analyze_cmd(data_dir: str | None) -> None:
     type=click.Path(),
     help="Directory for rendered site",
 )
-def render_cmd(output_dir: str) -> None:
+@click.option(
+    "--summary-path",
+    default="summary.json",
+    type=click.Path(),
+    help="Path to summary JSON",
+)
+def render_cmd(output_dir: str, summary_path: str) -> None:
     """Render static site."""
-    render(output_dir=output_dir)
+    render(output_dir=output_dir, summary_path=summary_path)
 
 
 @main.command()

--- a/braggard/renderer.py
+++ b/braggard/renderer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from textwrap import dedent
 
 from jinja2 import Template
@@ -37,13 +38,15 @@ HTML_TEMPLATE = Template(
 )
 
 
-def render(output_dir: str = "docs") -> None:
-    """Render ``summary.json`` into ``output_dir/index.html``."""
+def render(
+    output_dir: str = "docs", *, summary_path: str | Path = "summary.json"
+) -> None:
+    """Render ``summary_path`` into ``output_dir/index.html``."""
 
-    if not os.path.exists("summary.json"):
+    if not os.path.exists(summary_path):
         raise FileNotFoundError("Run `braggard analyze` first")
 
-    with open("summary.json", "r", encoding="utf-8") as f:
+    with open(summary_path, "r", encoding="utf-8") as f:
         summary = json.load(f)
 
     os.makedirs(output_dir, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,9 +38,10 @@ def test_cli_analyze_invokes_analyze(monkeypatch):
 def test_cli_render_invokes_render(monkeypatch):
     called = {}
 
-    def fake_render(output_dir="docs"):
+    def fake_render(*, output_dir="docs", summary_path="summary.json"):
         called["called"] = True
         called["output_dir"] = output_dir
+        called["summary_path"] = summary_path
 
     monkeypatch.setattr("braggard.cli.render", fake_render)
     runner = CliRunner()
@@ -48,6 +49,7 @@ def test_cli_render_invokes_render(monkeypatch):
     assert result.exit_code == 0
     assert called.get("called") is True
     assert called.get("output_dir") == "docs"
+    assert called.get("summary_path") == "summary.json"
 
 
 def test_cli_deploy_invokes_deploy(monkeypatch):

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -35,6 +35,21 @@ def test_render_custom_output_dir(tmp_path, monkeypatch):
     assert html_file.exists()
 
 
+def test_render_custom_summary_path(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "data.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    renderer.render(summary_path="data.json")
+
+    html_file = tmp_path / "docs" / "index.html"
+    assert html_file.exists()
+
+
 def test_render_requires_summary(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- allow `braggard.render` to read from a custom summary path
- expose `--summary-path` in the CLI
- document the new option in README
- support custom path in renderer tests

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_686d5acd76848328a3fe8e67387a8c4d