### PR TITLE
Add full GitHub history support

### DIFF
--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -23,12 +23,16 @@ def main() -> None:
 @click.option("--include-private", is_flag=True)
 @click.option("--since")
 @click.option("--data-dir", type=click.Path(), help="Directory for snapshot JSON")
+@click.option(
+    "--full-history", is_flag=True, help="Collect commit counts for entire repo history"
+)
 def collect_cmd(
     user: str,
     token: str | None,
     include_private: bool,
     since: str | None,
     data_dir: str | None,
+    full_history: bool,
 ) -> None:
     """Fetch data from GitHub."""
     collect(
@@ -37,6 +41,7 @@ def collect_cmd(
         include_private=include_private,
         since=since,
         data_dir=data_dir,
+        full_history=full_history,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,20 @@ def test_cli_collect_invokes_collect(monkeypatch):
     assert called.get("called") is True
 
 
+def test_cli_collect_full_history(monkeypatch):
+    called = {}
+
+    def fake_collect(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr("braggard.cli.collect", fake_collect)
+    runner = CliRunner()
+    result = runner.invoke(main, ["collect", "demo", "--full-history"])
+
+    assert result.exit_code == 0
+    assert called.get("full_history") is True
+
+
 def test_cli_analyze_invokes_analyze(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- support a `--full-history` flag for `braggard collect`
- fetch commit counts for each repository when collecting
- test new flag and history handling

## Testing
- `pre-commit run --files braggard/collector.py braggard/cli.py tests/test_cli.py tests/test_collector.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf33957788328a027aeff84dccd64