### PR TITLE
Add multiple output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ braggard deploy   # → pushes docs/ to gh-pages
 ```
 
 The `braggard render` command accepts `--summary-path` to load a summary JSON
-from a custom location instead of the default `summary.json`.
+from a custom location instead of the default `summary.json`. Use `--format`
+to choose between HTML (default), Markdown, or plain text output.
 
 Or simply enable the supplied **GitHub Action** (`.github/workflows/braggard.yml`) and let it run unattended.
 

--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -65,9 +65,16 @@ def analyze_cmd(data_dir: str | None) -> None:
     type=click.Path(),
     help="Path to summary JSON",
 )
-def render_cmd(output_dir: str, summary_path: str) -> None:
+@click.option(
+    "--format",
+    "output_format",
+    default="html",
+    type=click.Choice(["html", "markdown", "text"]),
+    help="Output format",
+)
+def render_cmd(output_dir: str, summary_path: str, output_format: str) -> None:
     """Render static site."""
-    render(output_dir=output_dir, summary_path=summary_path)
+    render(output_dir=output_dir, summary_path=summary_path, output_format=output_format)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,10 +52,11 @@ def test_cli_analyze_invokes_analyze(monkeypatch):
 def test_cli_render_invokes_render(monkeypatch):
     called = {}
 
-    def fake_render(*, output_dir="docs", summary_path="summary.json"):
+    def fake_render(*, output_dir="docs", summary_path="summary.json", output_format="html"):
         called["called"] = True
         called["output_dir"] = output_dir
         called["summary_path"] = summary_path
+        called["output_format"] = output_format
 
     monkeypatch.setattr("braggard.cli.render", fake_render)
     runner = CliRunner()
@@ -64,6 +65,7 @@ def test_cli_render_invokes_render(monkeypatch):
     assert called.get("called") is True
     assert called.get("output_dir") == "docs"
     assert called.get("summary_path") == "summary.json"
+    assert called.get("output_format") == "html"
 
 
 def test_cli_deploy_invokes_deploy(monkeypatch):
@@ -93,3 +95,19 @@ def test_cli_render_custom_dir(tmp_path, monkeypatch):
 
     assert result.exit_code == 0
     assert (tmp_path / "public" / "index.html").exists()
+
+
+def test_cli_render_custom_format(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "summary.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["render", "--format", "markdown"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / "docs" / "index.md").exists()

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -20,6 +20,23 @@ def test_render_creates_html(tmp_path, monkeypatch):
     assert "Braggard Report" in content
 
 
+def test_render_markdown(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "summary.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    renderer.render(output_format="markdown")
+
+    md_file = tmp_path / "docs" / "index.md"
+    assert md_file.exists()
+    content = md_file.read_text()
+    assert "# Braggard Report" in content
+
+
 def test_render_custom_output_dir(tmp_path, monkeypatch):
     summary = {
         "generated_at": "2025-01-01T00:00:00Z",
@@ -55,3 +72,18 @@ def test_render_requires_summary(tmp_path, monkeypatch):
 
     with pytest.raises(FileNotFoundError, match="Run `braggard analyze` first"):
         renderer.render()
+
+
+def test_render_text_format(tmp_path, monkeypatch):
+    summary = {
+        "generated_at": "2025-01-01T00:00:00Z",
+        "repos": [],
+        "aggregate": {"repo_count": 0, "total_stars": 0, "languages": {}},
+    }
+    (tmp_path / "summary.json").write_text(json.dumps(summary))
+    monkeypatch.chdir(tmp_path)
+
+    renderer.render(output_format="text")
+
+    txt_file = tmp_path / "docs" / "report.txt"
+    assert txt_file.exists()


### PR DESCRIPTION
## Summary
- add Markdown and text templates for rendering reports
- expose `--format` option in CLI to select output format
- document render output formats

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6893c4027c9883289ccaba8e5a6345d3