### PR TITLE
feat: allow custom summary path

### DIFF
--- a/braggard/analyzer.py
+++ b/braggard/analyzer.py
@@ -29,14 +29,19 @@ def _load_snapshots(data_dir: str | Path | None = None) -> list[dict]:
     return repos
 
 
-def analyze(*, data_dir: str | Path | None = None) -> None:
-    """Analyze collected JSON and write ``summary.json``.
+def analyze(
+    *, data_dir: str | Path | None = None, summary_path: str | Path | None = None
+) -> None:
+    """Analyze collected JSON and write a summary.
 
     Parameters
     ----------
     data_dir:
         Optional directory containing snapshot JSON files. Defaults to the
         ``paths.data_dir`` value from ``braggard.toml``.
+    summary_path:
+        Optional path to write the resulting ``summary.json``. Defaults to
+        ``summary.json`` in the current working directory.
     """
 
     repos = _load_snapshots(data_dir)
@@ -69,5 +74,7 @@ def analyze(*, data_dir: str | Path | None = None) -> None:
         },
     }
 
-    with open("summary.json", "w", encoding="utf-8") as f:
+    out_path = Path(summary_path or "summary.json")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)

--- a/braggard/cli.py
+++ b/braggard/cli.py
@@ -47,9 +47,15 @@ def collect_cmd(
 
 @main.command()
 @click.option("--data-dir", type=click.Path(), help="Directory with snapshot JSON")
-def analyze_cmd(data_dir: str | None) -> None:
+@click.option(
+    "--summary-path",
+    default="summary.json",
+    type=click.Path(),
+    help="Path to summary JSON",
+)
+def analyze_cmd(data_dir: str | None, summary_path: str) -> None:
     """Analyze collected data."""
-    analyze(data_dir=data_dir)
+    analyze(data_dir=data_dir, summary_path=summary_path)
 
 
 @main.command()

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -27,3 +27,25 @@ def test_analyze_creates_summary(tmp_path, monkeypatch):
     assert summary["aggregate"]["total_stars"] == 5
     assert summary["aggregate"]["languages"]["Python"] == 1
     assert summary["repos"][0]["ci_pass_rate"] == pytest.approx(2 / 3)
+
+
+def test_analyze_writes_to_custom_path(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sample = [
+        {
+            "name": "demo",
+            "stargazerCount": 5,
+            "primaryLanguage": {"name": "Python"},
+            "ciStatuses": ["SUCCESS", "FAILURE", "SUCCESS"],
+        }
+    ]
+    (data_dir / "snap.json").write_text(json.dumps(sample))
+
+    out_path = tmp_path / "out" / "result.json"
+    analyzer.analyze(data_dir=data_dir, summary_path=out_path)
+
+    assert out_path.exists()
+    summary = json.loads(out_path.read_text())
+    assert summary["aggregate"]["repo_count"] == 1
+    assert not (tmp_path / "summary.json").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,3 +113,34 @@ def test_cli_render_custom_format(tmp_path, monkeypatch):
 
     assert result.exit_code == 0
     assert (tmp_path / "docs" / "index.md").exists()
+
+
+def test_cli_analyze_custom_summary_path(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sample = [
+        {
+            "name": "demo",
+            "stargazerCount": 5,
+            "primaryLanguage": {"name": "Python"},
+            "ciStatuses": ["SUCCESS", "FAILURE", "SUCCESS"],
+        }
+    ]
+    (data_dir / "snap.json").write_text(json.dumps(sample))
+    monkeypatch.chdir(tmp_path)
+
+    summary_path = tmp_path / "custom.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "analyze",
+            "--data-dir",
+            str(data_dir),
+            "--summary-path",
+            str(summary_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert summary_path.exists()


### PR DESCRIPTION
## Summary
- allow `analyze` to write summary JSON to a custom path
- expose `--summary-path` flag on CLI `analyze`
- test custom summary path handling for `analyze` and CLI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d27995d548328a8a182d34e9dfe60