### PR TITLE
Use dataclass-based configuration

### DIFF
--- a/braggard/__init__.py
+++ b/braggard/__init__.py
@@ -8,10 +8,11 @@ __all__ = [
     "render",
     "deploy",
     "load_config",
+    "Config",
 ]
 
 from .collector import collect
 from .analyzer import analyze
 from .renderer import render
 from .deployer import deploy
-from .config import load_config
+from .config import Config, load_config

--- a/braggard/analyzer.py
+++ b/braggard/analyzer.py
@@ -14,7 +14,7 @@ def _load_snapshots(data_dir: str | Path | None = None) -> list[dict]:
     """Return a combined list of repositories from ``data_dir/*.json``."""
     if data_dir is None:
         cfg = load_config()
-        data_dir = cfg.get("paths", {}).get("data_dir", "data")
+        data_dir = cfg.paths.data_dir
     data_dir = Path(data_dir)
     repos: list[dict] = []
     for path in sorted(data_dir.glob("*.json")):

--- a/braggard/collector.py
+++ b/braggard/collector.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import urllib.request
 from urllib.error import HTTPError, URLError
 
-from .config import load_config
+from .config import Config, load_config
 from . import __version__
 
 
@@ -60,15 +60,15 @@ def collect(
     repository lifetime instead of the default ``metrics.commit_history_years``
     window from ``braggard.toml``.
     """
-    cfg: dict[str, dict] = {}
+    cfg: Config | None = None
     if user is None or include_private is None or data_dir is None:
         cfg = load_config()
         if user is None:
-            user = cfg.get("user", {}).get("handle")
+            user = cfg.user.handle
         if include_private is None:
-            include_private = cfg.get("user", {}).get("include_private", False)
+            include_private = cfg.user.include_private
         if data_dir is None:
-            data_dir = cfg.get("paths", {}).get("data_dir", "data")
+            data_dir = cfg.paths.data_dir
     data_dir = Path(data_dir)
     if user is None:
         raise ValueError("user must be provided")
@@ -110,7 +110,9 @@ def collect(
     # fetch commit history counts
     history_years = 0
     if not full_history:
-        history_years = int(cfg.get("metrics", {}).get("commit_history_years", 3))
+        if cfg is None:
+            cfg = load_config()
+        history_years = cfg.metrics.commit_history_years
 
     commit_query_template = """
     query($login: String!, $repo: String!%s) {

--- a/braggard/config.py
+++ b/braggard/config.py
@@ -2,15 +2,47 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 import os
 
 import tomllib
 
 
-def load_config(path: str | Path | None = None) -> dict[str, Any]:
-    """Return settings from ``braggard.toml``.
+@dataclass
+class UserConfig:
+    """Settings under the ``[user]`` table."""
+
+    handle: str
+    include_private: bool = False
+
+
+@dataclass
+class MetricsConfig:
+    """Settings under the ``[metrics]`` table."""
+
+    ci_pass_window: int = 100
+    commit_history_years: int = 3
+
+
+@dataclass
+class PathsConfig:
+    """Settings under the ``[paths]`` table."""
+
+    data_dir: str = "data"
+
+
+@dataclass
+class Config:
+    """Full configuration for Braggard."""
+
+    user: UserConfig = field(default_factory=lambda: UserConfig(handle=""))
+    metrics: MetricsConfig = field(default_factory=MetricsConfig)
+    paths: PathsConfig = field(default_factory=PathsConfig)
+
+
+def load_config(path: str | Path | None = None) -> Config:
+    """Return settings from ``braggard.toml`` as a :class:`Config` instance.
 
     Search order:
     1. ``path`` when provided
@@ -39,10 +71,27 @@ def load_config(path: str | Path | None = None) -> dict[str, Any]:
         if cand.is_file():
             with open(cand, "rb") as f:
                 data = tomllib.load(f)
-            return {
-                "user": data.get("user", {}),
-                "metrics": data.get("metrics", {}),
-                "paths": data.get("paths", {}),
-            }
+
+            user_data = data.get("user") or {}
+            handle = user_data.get("handle")
+            if not handle:
+                raise KeyError("Missing required key: user.handle")
+            user = UserConfig(
+                handle=str(handle),
+                include_private=bool(user_data.get("include_private", False)),
+            )
+
+            metrics_data = data.get("metrics") or {}
+            metrics = MetricsConfig(
+                ci_pass_window=int(metrics_data.get("ci_pass_window", 100)),
+                commit_history_years=int(
+                    metrics_data.get("commit_history_years", 3)
+                ),
+            )
+
+            paths_data = data.get("paths") or {}
+            paths = PathsConfig(data_dir=str(paths_data.get("data_dir", "data")))
+
+            return Config(user=user, metrics=metrics, paths=paths)
 
     raise FileNotFoundError("braggard.toml not found")


### PR DESCRIPTION
## Summary
- add `Config` dataclass with default `user`, `metrics`, and `paths` sections
- load config TOML into `Config` and raise clear errors for missing keys
- adjust collectors, analyzers, and tests for typed config defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d279b8a1c83288b64f1b4a83a26d7